### PR TITLE
resent cache at reset in rtrd.py

### DIFF
--- a/rtrd.py
+++ b/rtrd.py
@@ -152,6 +152,7 @@ class RTRConnHandler(socketserver.BaseRequestHandler):
     def handle_serial_query(self, buf):
         serial = struct.unpack('!I', buf)[0]
         dbg(">Serial query: %d" % serial)
+        self.server.db.set_serial(0)
         self.send_cacheresponse()
 
         for asn, ipnet, maxlen in self.server.db.get_announcements4(serial):


### PR DESCRIPTION
rtrd must resent all the cache after receiving a "reset query". However, it is not done because the last_serial is not reset before reaching the get_announcements4() method.

Reset last_serial to allow cache resent.

Link: https://www.rfc-editor.org/rfc/rfc8210.html#page-12